### PR TITLE
fix Files app: file download was not working

### DIFF
--- a/src/utils/files.js
+++ b/src/utils/files.js
@@ -61,12 +61,13 @@ export const decryptAndDownload = async ({
       const fileAsArrayBuffer = await fetch(url, {
         method: 'GET',
       }).then((response) => response.arrayBuffer())
+      const fileAsBlob = new Blob([fileAsArrayBuffer])
 
       let decryptedFile, metadata
       try {
         const resp = await LitJsSdk.decryptZipFileWithMetadata({
           authSig,
-          file: fileAsArrayBuffer,
+          file: fileAsBlob,
           litNodeClient: window.litNodeClient,
           additionalAccessControlConditions:
             file.additionalAccessControlConditions,


### PR DESCRIPTION
File download in `IPFS Encrypted Files` app does not work, throws error:
```
Expecting Blob or File type for parameter named file in Lit-JS-SDK function decryptZipFileWithMetadata(), but received \"ArrayBuffer\" type instead. value: {}
```

This PR fixes that error.
I've tested it locally.
